### PR TITLE
Removed as much of the dependencies on the w65c265 monitor as possible.

### DIFF
--- a/Mench Reloaded/Makefile
+++ b/Mench Reloaded/Makefile
@@ -8,6 +8,7 @@ EXAMPLES = \
 	bin/math.srec \
 	bin/music.srec \
 	bin/ping.srec \
+	bin/pwm_led.srec \
 	bin/qti.srec \
 	bin/servo.srec
 
@@ -31,7 +32,7 @@ bin/helloWorld.bin: examples/helloWorld.o
 bin/math.bin: examples/math.o src/math16.o src/print.o
 	$(LD65) -C mench.cfg -o bin/math.bin -m bin/math.map $^
 
-bin/music.bin: examples/music.o src/pbasic.o src/via.o src/print.o
+bin/music.bin: examples/music.o src/pbasic.o src/via.o
 	$(LD65) -C mench.cfg -o bin/music.bin -m bin/music.map $^
 
 bin/ping.bin: examples/ping.o src/pbasic.o src/via.o src/math16.o src/print.o

--- a/Mench Reloaded/examples/blink.asm
+++ b/Mench Reloaded/examples/blink.asm
@@ -8,7 +8,6 @@
 .include "common.inc"
 .include "pbasic.inc"
 .include "via.inc"
-.include "w65c265Monitor.inc"
 
 LED_PIN = $0000			; Port A pin 0
 

--- a/Mench Reloaded/examples/button.asm
+++ b/Mench Reloaded/examples/button.asm
@@ -14,7 +14,6 @@
 .include "common.inc"
 .include "pbasic.inc"
 .include "via.inc"
-.include "w65c265Monitor.inc"
 
 LED_PIN = $0000			; Port A pin 0
 BUTTON_PIN = $0008		; Port B pin 0

--- a/Mench Reloaded/examples/echo.asm
+++ b/Mench Reloaded/examples/echo.asm
@@ -5,7 +5,7 @@
 
 .include "ascii.inc"
 .include "common.inc"
-.include "w65c265Monitor.inc"
+.include "print.inc"
 
 ; Main entry point for the interpreter test
 .proc main

--- a/Mench Reloaded/examples/helloWorld.asm
+++ b/Mench Reloaded/examples/helloWorld.asm
@@ -3,7 +3,7 @@
 ; Martin Heermance <mheermance@gmail.com>
 ; -----------------------------------------------------------------------------
 
-.include "w65c265Monitor.inc"
+.include "print.inc"
 
 .A8
 .I16

--- a/Mench Reloaded/examples/math.asm
+++ b/Mench Reloaded/examples/math.asm
@@ -9,11 +9,10 @@
 .include "common.inc"
 .include "math16.inc"
 .include "print.inc"
-.include "w65c265Monitor.inc"
 
 ; Main entry point for the program.
 PUBLIC main
-	jsl SEND_CR		; start output on a newline
+	printcr			; start output on a newline
 	println enter
 	ON16MEM
 	ON16X

--- a/Mench Reloaded/examples/music.asm
+++ b/Mench Reloaded/examples/music.asm
@@ -10,9 +10,7 @@
 .include "ascii.inc"
 .include "common.inc"
 .include "pbasic.inc"
-.include "print.inc"
 .include "via.inc"
-.include "w65c265Monitor.inc"
 
 ; Tone generator register value
 ; N = (FCLK / (16 x F)) - 1
@@ -125,7 +123,6 @@ TG1 = 1				; Tone generator 1
 PUBLIC main
 	ON16MEM
 	ON16X
-	printcr			; start output on a newline
 	jsr viaInit		; one time VIA initialization.
 	lda #pachelbel
 	jsr playsong

--- a/Mench Reloaded/examples/ping.asm
+++ b/Mench Reloaded/examples/ping.asm
@@ -23,7 +23,6 @@
 .include "pbasic.inc"
 .include "print.inc"
 .include "via.inc"
-.include "w65c265Monitor.inc"
 
 PING_PIN = 8			; Port B pin 0
 PULSE_WIDTH = 5 * ONE_US	; Ping))) activated by a pulse of 2 or more uS

--- a/Mench Reloaded/examples/pwm_led.asm
+++ b/Mench Reloaded/examples/pwm_led.asm
@@ -12,7 +12,6 @@
 .include "pbasic.inc"
 .include "print.inc"
 .include "via.inc"
-.include "w65c265Monitor.inc"
 
 LED_PIN = 0			; Port B pin 0
 

--- a/Mench Reloaded/examples/qti.asm
+++ b/Mench Reloaded/examples/qti.asm
@@ -13,7 +13,6 @@
 .include "pbasic.inc"
 .include "print.inc"
 .include "via.inc"
-.include "w65c265Monitor.inc"
 
 LINE_SENSOR_PWR = $0008		; Optional as you can connect sensor to +5v
 LINE_SENSOR_IN  = $0009		; Data pin from line sensor.

--- a/Mench Reloaded/examples/servo.asm
+++ b/Mench Reloaded/examples/servo.asm
@@ -11,8 +11,8 @@
 .include "ascii.inc"
 .include "common.inc"
 .include "pbasic.inc"
+.include "print.inc"
 .include "via.inc"
-.include "w65c265Monitor.inc"
 
 SERVO_PIN = $0008		; Port B pin 0
 
@@ -23,7 +23,7 @@ SERVO_STEP = (SERVO_MAX - SERVO_MIN)/100
 ; Main entry point for the program.
 PUBLIC main
 	jsr viaInit		; one time VIA initialization.
-	jsl SEND_CR		; start output on a newline
+	printcr			; start output on a newline
 	ON16MEM
 	ON16X
 

--- a/Mench Reloaded/include/print.inc
+++ b/Mench Reloaded/include/print.inc
@@ -4,6 +4,8 @@
 ; Martin Heermance <mheermance@gmail.com>
 ; -----------------------------------------------------------------------------
 
+.include "w65c265Monitor.inc"
+
 ;
 ; Macros
 ;

--- a/Mench Reloaded/src/print.asm
+++ b/Mench Reloaded/src/print.asm
@@ -7,7 +7,6 @@ __print_asm__ = 1
 
 .include "common.inc"
 .include "print.inc"
-.include "w65c265Monitor.inc"
 
 ;
 ; Functions


### PR DESCRIPTION
The goal is to migrate all functions to conio and print. This will make code more portable between 65816 systems.